### PR TITLE
use dotenv for development env

### DIFF
--- a/lib/generator/Gemfile
+++ b/lib/generator/Gemfile
@@ -28,4 +28,5 @@ group :development do
   gem 'fakeweb'
   gem 'mocha', require: false
   gem 'byebug'
+  gem 'dotenv'
 end

--- a/lib/generator/config.ru
+++ b/lib/generator/config.ru
@@ -1,2 +1,7 @@
+if Gem::Specification.find_all_by_name('dotenv').any?
+  require 'dotenv'
+  Dotenv.load
+end
+
 require './lib/app'
 SinatraApp.run!


### PR DESCRIPTION
When creating the application I get a problem. Shopify not authorize my app, because client_id was not send in params. I have investigated and discovered dotenv not set ENV variables.
