### PR TITLE
Fixes for new shopify gem

### DIFF
--- a/lib/generator/config/database.yml
+++ b/lib/generator/config/database.yml
@@ -3,6 +3,9 @@ development:
   database: db/shopify_app.sqlite3
   pool: 5
 
+production:
+  url: <%= ENV['DATABASE_URL'] %>
+  
 test:
   adapter: sqlite3
   database: "db/test.sqlite3"

--- a/lib/sinatra/shopify-sinatra-app.rb
+++ b/lib/sinatra/shopify-sinatra-app.rb
@@ -189,7 +189,9 @@ module Sinatra
         provider :shopify,
                  app.settings.api_key,
                  app.settings.shared_secret,
-
+                 #Fixes for new Shopify callback issues
+                 redirect_uri: base_url + "/auth/shopify/callback",
+                 callback_url: base_url + "/auth/shopify/callback",
                  scope: app.settings.scope,
 
                  setup: lambda { |env|


### PR DESCRIPTION
- Must set the callback URI in the App admin section to

<baseurl> + "/auth/shopify/callback"