### PR TITLE
Always oauth

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,3 @@
+0.1.6
+-----
+* Changed install method to after_shopify_auth. Implementations of this method must now be idempotent as this will be called anytime the app is auth'd which may be due to just a lost session and not necessarily an install.

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
-ruby '2.1.5'
+
+ruby "2.1.5"
 
 gem 'sinatra'
 gem 'sinatra-redis'

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ class OrderWebhookJob
 end
 ```
 
-**install** - This is a private method provided with the framework that gets called when the app is authorized for the first time. You should fill this method in with anything you need to initialize on install, for example webhooks and services on Shopify or any other database models you have created specific to a shop.
+**after_shopify_auth** - This is a private method provided with the framework that gets called whenever the app is authorized. You should fill this method in with anything you need to initialize, for example webhooks and services on Shopify or any other database models you have created specific to a shop. Note that this method will be called anytime the auth flow is completed so this method should be idempotent (running it twice has the same effect as running it once).
 
 **logout** - This method clears the current session
 
@@ -125,7 +125,7 @@ end
 
 shopify-sinatra-app includes sinatra/activerecord for creating models that can be persisted in the database. You might want to read more about sinatra/activerecord and the methods it makes available to you: [https://github.com/janko-m/sinatra-activerecord](https://github.com/janko-m/sinatra-activerecord)
 
-shopify-sinatra-app also includes `rack-flash3` and the flash messages are forwarded to the Shopify Embedded App SDK (see the code in `views/layouts/application.erb`). Flash messages are useful for signalling to your users that a request was successful without changing the page. The following is an example of how to use a flash message in a route:
+shopify-sinatra-app also includes `rack-flash3` and the flash messages are forwarded to the Shopify Embedded App SDK (see the code in `views/layouts/application.erb`). Flash messages are useful for signaling to your users that a request was successful without changing the page. The following is an example of how to use a flash message in a route:
 
 ```
 post '/flash_message' do
@@ -158,7 +158,7 @@ While running the app locally you'll be able to test the install and other route
 ./ngrok 4567
 ```
 
-Ngrok will report what address your app is available at, leave Ngrok running and then create your webhook to point to the ngrok url plus your route e.g. `<ngrok url>/webhook_test.json`. Now trigger the webhook you are testing and it will get forwarded through ngrok to your local web application allowing you to use debuggers and repls to complete your code.
+Ngrok will report what address your app is available at, leave Ngrok running and then create your webhook to point to the ngrok url plus your route e.g. `<ngrok url>/webhook_test.json`. Now trigger the webhook you are testing and it will get forwarded through ngrok to your local web application allowing you to use debuggers and REPLs to complete your code.
 
 Testing
 -------

--- a/lib/generator/Gemfile
+++ b/lib/generator/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.0.0'
+ruby "2.1.5"
 
 gem 'sinatra'
 gem 'sinatra-redis'

--- a/lib/generator/Gemfile.lock
+++ b/lib/generator/Gemfile.lock
@@ -122,6 +122,7 @@ DEPENDENCIES
   activesupport
   attr_encrypted
   byebug
+  dotenv
   fakeweb
   foreman
   minitest

--- a/lib/generator/lib/app.rb
+++ b/lib/generator/lib/app.rb
@@ -31,7 +31,7 @@ class SinatraApp < Sinatra::Base
   # This method gets called when your app is installed.
   # setup any webhooks or services you need on Shopify
   # inside here.
-  def install
+  def after_shopify_auth
     shopify_session do
       # create an uninstall webhook, this webhook gets sent
       # when your app is uninstalled from a shop. It is good
@@ -42,7 +42,11 @@ class SinatraApp < Sinatra::Base
         address: "#{base_url}/uninstall",
         format: 'json'
       )
-      uninstall_webhook.save
+      begin
+        uninstall_webhook.save!
+      rescue => e
+        raise unless uninstall_webhook.persisted?
+      end
     end
 
     redirect '/'

--- a/lib/sinatra/shopify-sinatra-app.rb
+++ b/lib/sinatra/shopify-sinatra-app.rb
@@ -14,8 +14,9 @@ require 'omniauth-shopify-oauth2'
 module Sinatra
   module Shopify
     module Methods
-      def install
-        fail NotImplementedError
+
+      # designed to be overriden
+      def after_shopify_auth
       end
 
       def logout
@@ -211,7 +212,7 @@ module Sinatra
         shop.token = token
         shop.save!
 
-        #install
+        after_shopify_auth()
 
         session[:shopify] = {shop: shop_name, token: token}
         return_to = env['omniauth.params']['return_to']

--- a/lib/sinatra/shopify-sinatra-app.rb
+++ b/lib/sinatra/shopify-sinatra-app.rb
@@ -40,11 +40,13 @@ module Sinatra
       end
 
       def shopify_session(&blk)
+        return_to = request.env['sinatra.route'].split(' ').last
+
         if !session.key?(:shopify)
-          authenticate
+          authenticate(return_to)
         elsif params[:shop].present? && session[:shopify][:shop] != sanitize_shop_param(params)
           logout
-          authenticate
+          authenticate(return_to)
         else
           shop_name = session[:shopify][:shop]
           token = session[:shopify][:token]

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,7 @@
 
 cd lib/generator/test
 
+bundle install
 bundle exec rake test:prepare
 bundle exec rake test
 


### PR DESCRIPTION
Changes:
  * Always redo the auth flow and update the shop model rather than trying to differentiate between a new install and a lost session. This ends up being simpler and the only caveat is that the install (renamed to after_shopify_auth) must be idempotent