### PR TITLE
Completely delete session data on logout

### DIFF
--- a/lib/sinatra/shopify-sinatra-app.rb
+++ b/lib/sinatra/shopify-sinatra-app.rb
@@ -19,7 +19,7 @@ module Sinatra
       end
 
       def logout
-        session[:shopify] = nil
+        session.delete(:shopify)
       end
 
       def base_url


### PR DESCRIPTION
Fix for #21 

In testing, I noticed another issue. Session data is stored in the cookie. However, logout is called when my app receives the uninstall instruction from shopify via a webhook. If an app is uninstalled, but then the browser (not knowing it was uninstalled) makes another request, shopify-sinatra-app (seeing the old session data from the cookie) doesn't attempt to reauthenticate, but `current_shop` returns nil since the shop was deleted from the database.

Do you think the session data should be destroyed if the shop data is missing, to keep these in sync?