### PR TITLE
Fix cookie name

### DIFF
--- a/lib/sinatra/shopify-sinatra-app.rb
+++ b/lib/sinatra/shopify-sinatra-app.rb
@@ -188,7 +188,7 @@ module Sinatra
 
       app.use Rack::Flash, sweep: true
       app.use Rack::MethodOverride
-      app.use Rack::Session::Cookie, key: '#{base_url}.session',
+      app.use Rack::Session::Cookie, key: 'rack.session',
                                      path: '/',
                                      secret: app.settings.secret,
                                      expire_after: 60 * 30 # half an hour in seconds

--- a/lib/sinatra/shopify-sinatra-app.rb
+++ b/lib/sinatra/shopify-sinatra-app.rb
@@ -19,7 +19,7 @@ module Sinatra
       end
 
       def logout
-        session[:shopify] = nil
+        session.delete(:shopify)
       end
 
       def base_url


### PR DESCRIPTION
This bug is causing duplicate cookies to be created, which is causing OAUTH issues. The OAUTH state (cryptographic nonce) is tied to the session cookie, and as far as I can tell the duplicate cookie is causing a "CSRF detected" error from OmniAuth. This appears to fix it.