### PR TITLE
Update deprecated digest class

### DIFF
--- a/lib/sinatra/shopify-sinatra-app.rb
+++ b/lib/sinatra/shopify-sinatra-app.rb
@@ -153,7 +153,7 @@ module Sinatra
 
       def verify_shopify_webhook
         data = request.body.read.to_s
-        digest = OpenSSL::Digest::Digest.new('sha256')
+        digest = OpenSSL::Digest.new('sha256')
         calculated_hmac = Base64.encode64(OpenSSL::HMAC.digest(digest, settings.shared_secret, data)).strip
         request.body.rewind
 


### PR DESCRIPTION
`OpenSSL::Digest::Digest` is deprecated. This PR updates it to `OpenSSL::Digest`