### PR TITLE
Authenticate if shop present in params

### DIFF
--- a/lib/sinatra/shopify-sinatra-app.rb
+++ b/lib/sinatra/shopify-sinatra-app.rb
@@ -218,7 +218,11 @@ module Sinatra
                                 secret: app.settings.shared_secret)
 
       app.get '/install' do
-        erb :install, layout: false
+        if params[:shop].present?
+          authenticate
+        else
+          erb :install, layout: false
+        end
       end
 
       app.post '/login' do


### PR DESCRIPTION
Hi! 

I send my app to shopify store and the reviewer gives me such suggestion:

Your app doesn't [authenticate](https://help.shopify.com/en/api/getting-started/authentication/oauth#step-4-making-authenticated-requests) after it is uninstalled and reinstalled on the same store. When an app is uninstalled all permissions from the store become inactive. The app will need to [reauthenticate with OAuth](https://screenshot.click/10-43-w5dfb-10lus.mp4) when a merchant reinstalls your app.