### PR TITLE
Update Webhook Handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+0.5.0
+-----
+* replace webhook_session and webhook_job with shopify_webhook
+* remove redis and resque as dependencies
+
 0.4.0
 -----
 * update to sinatra 2.0.1

--- a/example/Procfile
+++ b/example/Procfile
@@ -1,2 +1,1 @@
 web: bundle exec rackup config.ru -p $PORT
-resque: env TERM_CHILD=1 RESQUE_TERM_TIMEOUT=7 QUEUE=default bundle exec rake resque:work

--- a/example/src/app.rb
+++ b/example/src/app.rb
@@ -22,7 +22,7 @@ class SinatraApp < Sinatra::Base
   # stores more data.
   post '/uninstall' do
     webhook_session do |params|
-      current_shop.destroy
+      Shop.find_by(name: current_shop_name).destroy
     end
   end
 

--- a/shopify-sinatra-app.gemspec
+++ b/shopify-sinatra-app.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'shopify-sinatra-app'
-  s.version = '0.4.1'
+  s.version = '0.5.0'
 
   s.summary     = 'A classy shopify app'
   s.description = 'A Sinatra extension for building Shopify Apps. Akin to the shopify_app gem but for Sinatra'
@@ -14,13 +14,10 @@ Gem::Specification.new do |s|
   s.executables << 'shopify-sinatra-app-generator'
 
   s.add_runtime_dependency 'sinatra', '~> 2.0.2'
-  s.add_runtime_dependency 'sinatra-redis', '~> 0.3.0'
   s.add_runtime_dependency 'sinatra-activerecord', '~> 2.0.9'
   s.add_runtime_dependency 'rack-flash3', '~> 1.0.5'
   s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'attr_encrypted', '~> 3.1.0'
-
-  s.add_runtime_dependency 'resque'
 
   s.add_runtime_dependency 'shopify_api'
   s.add_runtime_dependency 'omniauth-shopify-oauth2'


### PR DESCRIPTION
This PR replaces the `webhook_session` and `webhook_job` methods with one newer and simpler method `shopify_webhook`.

Why?

Well honestly I am having to add background processing to one of my apps and I don't love how I did it in this framework. The configuration of the background queue is important and shouldn't be buried in a dependency. Also I intend to use Sidekiq not Resque and this framework shouldn't force me to use a certain queue.

The new `shopify_webhook` method is simpler, it parses the webhook and ensures it is valid then yields the shop_name and the webhook body. It lets the user take over from here - if you want to process inline then you can still load the shop model and activate an API session. You're also free to queue in the system of your choice to process the hook.

If anyone is updating and needs these methods as they were then they can just copy them into their sinatra app class and continue to use them.