### PR TITLE
fix app actions when session has expired

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+0.7.0
+-----
+* make base_url private (users can add back in their app easily if needed)
+* store request params in the session so they can be retrieved after the omniauth flow. This fixes app actions from the admin if the user's session has expired
+* refactored some smaller methods to make the shopify_session method easier on the eyes.
+
 0.6.0
 -----
 * remove current_shop* methods in favor of yielding shop_name to the block methods

--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ It's impossible to control the flow of webhooks to your app from Shopify especia
 
 **logout** - This method clears the current session
 
-**base_url** - This returns the url of the app
-
 shopify-sinatra-app includes sinatra/activerecord for creating models that can be persisted in the database. You might want to read more about sinatra/activerecord and the methods it makes available to you: [https://github.com/janko-m/sinatra-activerecord](https://github.com/janko-m/sinatra-activerecord)
 
 shopify-sinatra-app also includes `rack-flash3` and the flash messages are forwarded to the Shopify Embedded App SDK (see the code in `views/layouts/application.erb`). Flash messages are useful for signalling to your users that a request was successful without changing the page. The following is an example of how to use a flash message in a route:

--- a/shopify-sinatra-app.gemspec
+++ b/shopify-sinatra-app.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'shopify-sinatra-app'
-  s.version = '0.6.0'
+  s.version = '0.7.0'
 
   s.summary     = 'A classy shopify app'
   s.description = 'A Sinatra extension for building Shopify Apps. Akin to the shopify_app gem but for Sinatra'


### PR DESCRIPTION
App actions with a expired session were broken (https://github.com/kevinhughes27/shopify-tax-receipts/issues/6) because the redirect after going through the omniauth flow to get a new session didn't include the original request params (aka the ID from shopify to act upon). Omniauth doesn't allow extra params in the URL so I have to store them in the session insead.

I also made base_url private (I was going to remove it but some other methods use it still. private achieves the goal of reducing the public API).